### PR TITLE
Reduce network usage

### DIFF
--- a/lua/netwrapper/sh_netwrapper.lua
+++ b/lua/netwrapper/sh_netwrapper.lua
@@ -86,6 +86,9 @@ netwrapper.MaxRequests = CreateConVar( "netwrapper_max_requests",  -1, bit.bor( 
 --	 unlike the ENTITY:SetNW* library.
 --]]--
 function ENTITY:SetNetVar( key, value )
+	
+	if ( netwrapper.GetNetVars( self:EntIndex() )[ key ] == value ) then return end
+	
 	netwrapper.StoreNetVar( self:EntIndex(), key, value )
 	
 	if ( SERVER ) then 


### PR DESCRIPTION
If you use ENTITY:SetNetVar( Key, Value ) where the value is equal to the current value, don't bother continuing. This will reduce the networking if someone accidentally calls this in a think hook.
