### PR TITLE
Extend the scope of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ The NetWrapper library is a simple wrapper over Garry's standard net library to 
 networking without needing to care about the type of data you are networking (unlike the ENTITY:SetNetworked* library)
 and without needing to create dozens of networked strings for net messages.
 
-There are 2 ways to network data with the NetWrapper library:
+There are 4 ways to network data with the NetWrapper library:
 * Net Vars
 * Net Requests
+* Client Vars
+* Global Vars
 
 #### Net Vars
 If you are looking to replace your existing scripts' use of the ENTITY:SetNW*/ENTITY:SetDT* functions, Net Vars
@@ -116,6 +118,172 @@ to the server asking for the value stored at the 'Owner' key.
 Since the 'Owner' was set earlier, the server will reply to the client's request by sending a net message back with the entity and key/value pair.
 When the clients receives the message, the value is stored in the netwrapper.requests table and will be retrieved with any subsequent calls to ent:GetNetRequest( "Owner" ).
 
+
+#### Client Vars
+Client Vars use the same technology as Net Vars behind the scenes, with the main difference being that the values will only be networked to that specific client.
+
+
+* Setting client values:
+
+```
+-- if run on the server, this key/value pair will be networked to the associated player only
+PLAYER:SetClientVar( key, value )
+```
+
+* Getting client values:
+
+```
+-- this will attempt to grab the value stored at the key
+PLAYER:GetClientVar( key, default )
+
+-- or clientside only
+netwrapper.GetClientVar( key, default ) = LocalPlayer():GetClientVar( key, default )
+
+```
+    
+Where 'default' is the default value you would like returned if the key doesn't exist.
+If a default value isn't provided and the key doesn't exist, nil will be returned.
+
+##### Example:
+
+If you wanted to network a player's money, which other players do not need to know about
+```
+hook.Add( "PlayerInitialSpawn", "SetPlayerMoney", function( ply )
+    local money = ... -- grab the money somewhere
+    ply:SetClientVar( "Money", money )
+end )
+```
+As soon as ply:SetClientVar() is called, a net message will be sent to the respective client with the key/value pair for the money.
+
+If you wanted to show the player's money in a GM:HUDPaint hook, you could do something like the following:
+```
+hook.Add( "HUDPaint", "ShowPlayerMoney", function( )
+    local money = netwrapper.GetClientVar( "Money" )
+    if ( not money ) then return end 
+    
+    draw.SimpleText( tostring( money ), ...  -- etc
+end )
+```
+
+
+#### Global Vars
+Global Vars are a wrapper around Net Vars.
+Internally, they translate to game.GetWorld():Set/GetNetVar()
+
+
+* Setting global values:
+
+```
+-- if run on the server, this key/value pair will be broadcasted to all players
+netwrapper.SetGlobalVar( key, value )
+```
+
+* Getting global values:
+
+```
+-- this will attempt to grab the value stored at the key
+netwrapper.GetGlobalVar( key, value, default )
+
+```
+    
+Where 'default' is the default value you would like returned if the key doesn't exist.
+If a default value isn't provided and the key doesn't exist, nil will be returned.
+
+
+
+#### Net Hooks
+NetWrapper also exposes a hook functionality. 
+This allows you to have callback function be called whenever data changes whether it be Net Vars, Client Vars or Global Vars. 
+**Net Requests are currently unsupported.**
+
+Hooks require you to specify
+1. The key for which you would like to listen to
+2. A unique identifier for the hook. This can be of any type you want.
+
+**If the unique identifier is a table with an IsValid method, NetWrapper will call the IsValid function every time before calling the hook, and will automatically remove the hook if IsValid() returns false.**
+
+This makes it easy to add a hook with an entity or panel object as the identifier.
+
+* Adding and removing net hooks:
+
+```
+-- Add a hook for Global variables
+netwrapper.AddGlobalHook( key, name, fn( key, value ) )
+netwrapper.RemoveGlobalHook( key, name )
+
+-- Add a hook that gets called whenever ANY entity's <key>'s <value> changes
+netwrapper.AddNetHook( key, name, fn( ent, key, value ))
+netwrapper.RemoveNetHook( key, name )
+
+-- Add a hook specific to this entity's <key>'s <value> changing
+ent:AddNetHook( key, name, fn( ent, key, value ))
+ent:RemoveNetHook( key, name )
+
+-- Automatically remove the hook when the entity gets removed
+ent:AddNetHook( key, ent, fn( ent, key, value ))
+
+-- Could be useful server-side too
+ply:AddCLNetHook( key, name, fn( ent, key, value ) )
+ply:RemoveCLnetHook( key, name )
+
+-- Once again automatically remove the hook when the identifier:IsValid() returns false
+ply:AddCLNetHook( key, ply, fn( ent, key, value ) )
+
+netwrapper.AddCLNetHook( key, name, fn( ent, key, value ) )
+netwrapper.RemoveCLHook( key, name )
+```
+
+##### Example:
+Add a ClientVar NetHook to reflect changes in a panel that gets automatically removed when the panel is removed
+```
+local label = vgui.Create( "DLabel" )
+
+netwrapper.AddCLNetHook( "Money", label, function( ent, key, value )
+    -- This hook gets removed if not IsValid( label ) so no need to check here!
+
+    label:SetText( "Money: " .. value )
+end)
+```
+
+
+#### Persistence
+NetWrapper allows you to easily restore a player's data (NetVars, NetRequests, ClientVars) if the player were to reconnect.
+
+This persistence is stored within the lua state. **This means it resets upon map change or server restart**
+
+It is only useful for **VOLATILE** data, such as a player's score or kill count in the current map or round.
+
+When a player disconnects, any NetVars, NetRequests or ClientVars whose key has been defined as a persistent variable will be saved and associated with their Steam ID. When the player reconnects, an attempt is made at restoring those values.
+
+* Defining a persistent value:
+```
+-- This will save any NetVar, NetRequest or GlobalVar with this key when a player disconnects.
+netwrapper.DefinePersistentVar( key )
+
+
+-- If, for whatever reason, you need to prevent a value from being saved for X amount of time,
+-- you can unregister it using the following function and netwrapper will discard the values with
+-- the associated key when a player disconnects.
+
+-- Note that this does NOT erase values of previously disconnected / pending players.
+netwrapper.UndefinePersistenceVar( key ) 
+```
+
+##### Example:
+Store a player's temporary happiness value and restore it on reconnect
+```
+netwrapper.DefinePersistenceVar( "Happiness" )
+
+ply:SetNetVar( "Happiness", 6 )
+ply:Kick()
+
+-- Player reconnects
+
+print( ply:GetNetVar( "Happiness" ) )
+-- 6
+```
+
+
 QUESTIONS & ANSWERS
 -------------------
 
@@ -138,7 +306,7 @@ What you CAN network:
 ### Q: How often is the data networked? 
 
 A: 
-##### For Net Vars:
+##### For Net Vars, Client Vars and Global Vars:
 Every time you use ENTITY:SetNetVar( key, value ) from the server, the data will be networked to any clients via net message.
 
 If you set a value on a player and then change that value 5 minutes later, the data will have been broadcasted only 2 times

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There are 4 ways to network data with the NetWrapper library:
 * Client Vars
 * Global Vars
 
-#### Net Vars
+## Net Vars
 If you are looking to replace your existing scripts' use of the ENTITY:SetNW*/ENTITY:SetDT* functions, Net Vars
 are the way to go.
 
@@ -24,14 +24,14 @@ would with the standard networking libraries.
 
 * Setting networked values:
 
-```
+```lua
 -- if run on the server, this key/value pair will be networked to all clients
 ENTITY:SetNetVar( key, value )
 ```
 
 * Getting networked values:
 
-```
+```lua
 -- if run on the client, this will attempt to grab the value stored at the key
 ENTITY:GetNetVar( key, default )
 ```
@@ -39,10 +39,10 @@ ENTITY:GetNetVar( key, default )
 Where 'default' is the default value you would like returned if the key doesn't exist.
 If a default value isn't provided and the key doesn't exist, nil will be returned.
 
-##### Example:
+### Example:
 
 If you wanted to network a title on a player when they connect, you could do something like the following:
-```
+```lua
 hook.Add( "PlayerInitialSpawn", "SetPlayerTitle", function( ply )
     local title = ... -- grab the title somewhere
     ply:SetNetVar( "Title", title )
@@ -52,7 +52,7 @@ As soon as ply:SetNetVar() is called, a net message will be broadcasted to all c
 key/value pair for the title.
 
 If you wanted to show the player's title in a GM:PostPlayerDraw hook, you could do something like the following:
-```
+```lua
 hook.Add( "PostPlayerDraw", "ShowPlayerTitle", function( ply )
     -- retrieve the player's title if one has been networked, otherwise returns nil
     -- if a title hasn't been networked yet, don't try drawing it
@@ -65,7 +65,7 @@ hook.Add( "PostPlayerDraw", "ShowPlayerTitle", function( ply )
 end )
 ```
 
-#### Net Requests
+## Net Requests
 Net Requests are a new feature in the NetWrapper library. They allow you to determine exactly when a client asks the server
 for a value to be networked to them by using ENTITY:SendNetRequest( key ). 
 
@@ -81,13 +81,13 @@ to the client only when they ask for it (such as when they look directly at it).
 
 * Setting net requests:
 
-```
+```lua
 ENTITY:SetNetRequest( key, value ) -- if run on the server, this key/value pair will be stored in a serverside table that the client can request from
 ```
 	
 * Getting net requests:
 
-```
+```lua
 ENTITY:SendNetRequest( key ) -- when run on the client, this will send a net message to the server asking for the value stored on the entity at the given key
 ENTITY:GetNetRequest( key, default ) -- once the client has received the value from the server, subsequent calls to ENTITY:GetNetRequest() will return the value
 ```
@@ -95,17 +95,17 @@ ENTITY:GetNetRequest( key, default ) -- once the client has received the value f
 Where 'default' is the default value you would like returned if the key doesn't exist.
 If a default value isn't provided and the key doesn't exist, nil will be returned.
 	
-##### Example:
+### Example:
 
 If you want to network the owner's name on props but don't want to flood connecting clients with hundreds of possible net messages, 
 you can do something like the following:
-```
+```lua
 -- some serverside function that pairs up the player with the entity they spawned
 ent:SetNetRequest( "Owner", ply:Nick() )
 ```
 
 Now the value has been stored in the netwrapper.requests table and can be accessed by clients when they request it:
-```
+```lua
 -- somewhere clientside
 local owner = ent:GetNetRequest( "Owner" )
 if ( not owner ) then ent:SendNetRequest( "Owner" ) end
@@ -119,20 +119,20 @@ Since the 'Owner' was set earlier, the server will reply to the client's request
 When the clients receives the message, the value is stored in the netwrapper.requests table and will be retrieved with any subsequent calls to ent:GetNetRequest( "Owner" ).
 
 
-#### Client Vars
+## Client Vars
 Client Vars use the same technology as Net Vars behind the scenes, with the main difference being that the values will only be networked to that specific client.
 
 
 * Setting client values:
 
-```
+```lua
 -- if run on the server, this key/value pair will be networked to the associated player only
 PLAYER:SetClientVar( key, value )
 ```
 
 * Getting client values:
 
-```
+```lua
 -- this will attempt to grab the value stored at the key
 PLAYER:GetClientVar( key, default )
 
@@ -144,10 +144,10 @@ netwrapper.GetClientVar( key, default ) = LocalPlayer():GetClientVar( key, defau
 Where 'default' is the default value you would like returned if the key doesn't exist.
 If a default value isn't provided and the key doesn't exist, nil will be returned.
 
-##### Example:
+### Example:
 
 If you wanted to network a player's money, which other players do not need to know about
-```
+```lua
 hook.Add( "PlayerInitialSpawn", "SetPlayerMoney", function( ply )
     local money = ... -- grab the money somewhere
     ply:SetClientVar( "Money", money )
@@ -156,7 +156,7 @@ end )
 As soon as ply:SetClientVar() is called, a net message will be sent to the respective client with the key/value pair for the money.
 
 If you wanted to show the player's money in a GM:HUDPaint hook, you could do something like the following:
-```
+```lua
 hook.Add( "HUDPaint", "ShowPlayerMoney", function( )
     local money = netwrapper.GetClientVar( "Money" )
     if ( not money ) then return end 
@@ -166,21 +166,21 @@ end )
 ```
 
 
-#### Global Vars
+## Global Vars
 Global Vars are a wrapper around Net Vars.
 Internally, they translate to game.GetWorld():Set/GetNetVar()
 
 
 * Setting global values:
 
-```
+```lua
 -- if run on the server, this key/value pair will be broadcasted to all players
 netwrapper.SetGlobalVar( key, value )
 ```
 
 * Getting global values:
 
-```
+```lua
 -- this will attempt to grab the value stored at the key
 netwrapper.GetGlobalVar( key, value, default )
 
@@ -191,7 +191,7 @@ If a default value isn't provided and the key doesn't exist, nil will be returne
 
 
 
-#### Net Hooks
+## Net Hooks
 NetWrapper also exposes a hook functionality. 
 This allows you to have callback function be called whenever data changes whether it be Net Vars, Client Vars or Global Vars. 
 **Net Requests are currently unsupported.**
@@ -206,7 +206,7 @@ This makes it easy to add a hook with an entity or panel object as the identifie
 
 * Adding and removing net hooks:
 
-```
+```lua
 -- Add a hook for Global variables
 netwrapper.AddGlobalHook( key, name, fn( key, value ) )
 netwrapper.RemoveGlobalHook( key, name )
@@ -233,9 +233,9 @@ netwrapper.AddCLNetHook( key, name, fn( ent, key, value ) )
 netwrapper.RemoveCLHook( key, name )
 ```
 
-##### Example:
+### Example:
 Add a ClientVar NetHook to reflect changes in a panel that gets automatically removed when the panel is removed
-```
+```lua
 local label = vgui.Create( "DLabel" )
 
 netwrapper.AddCLNetHook( "Money", label, function( ent, key, value )
@@ -246,7 +246,7 @@ end)
 ```
 
 
-#### Persistence
+## Persistence
 NetWrapper allows you to easily restore a player's data (NetVars, NetRequests, ClientVars) if the player were to reconnect.
 
 This persistence is stored within the lua state. **This means it resets upon map change or server restart**
@@ -256,7 +256,7 @@ It is only useful for **VOLATILE** data, such as a player's score or kill count 
 When a player disconnects, any NetVars, NetRequests or ClientVars whose key has been defined as a persistent variable will be saved and associated with their Steam ID. When the player reconnects, an attempt is made at restoring those values.
 
 * Defining a persistent value:
-```
+```lua
 -- This will save any NetVar, NetRequest or GlobalVar with this key when a player disconnects.
 netwrapper.DefinePersistentVar( key )
 
@@ -269,9 +269,9 @@ netwrapper.DefinePersistentVar( key )
 netwrapper.UndefinePersistenceVar( key ) 
 ```
 
-##### Example:
+### Example:
 Store a player's temporary happiness value and restore it on reconnect
-```
+```lua
 netwrapper.DefinePersistenceVar( "Happiness" )
 
 ply:SetNetVar( "Happiness", 6 )
@@ -339,4 +339,6 @@ use ENTITY:SendNetRequest( key ) to network the value.
 ### Q: What happens to the networked data on a player that disconnected, or an entity that was removed? 
 
 A: When a player disconnects or an entity is removed, the netwrapper library will automatically sanitize its tables by 
-using the GM:EntityRemoved hook on the server and removing any data it currently has networked with that entity. The server will then send a net message to the client informing them to sanitize their clientside tables.
+using the GM:EntityRemoved hook on the server and removing any [non-persistent](#persistence) data it currently has networked with that entity. The server will then send a net message to the client informing them to sanitize their clientside tables.
+
+[Persistent](#persistence) values will be restored when a player reconnects.

--- a/lua/autorun/netwrapper.lua
+++ b/lua/autorun/netwrapper.lua
@@ -2,8 +2,9 @@
 	File name:
 		autorun.lua
 	
-	Author:
+	Authors:
 		Mista-Tea ([IJWTB] Thomas)
+		xaviergmail (Xavier Bergeron)
 	
 	License:
 		The MIT License (copy/modify/distribute freely!)
@@ -47,12 +48,17 @@
 		
 		Any subsequent calls to Entity(1):GetNetVar( "TeamName" ) will 
 		 return "Another Example".
+
+		Other features, such as hooks, client-specific variables, global variables
+		 as well as persistence are also available. Please refer to the README.md
+		 as well as example.lua for more information.
 	
 	Changelog:
 		- March   9th, 2014:    Created
 		- April   5th, 2014:    Added to GitHub
 		- April   7th, 2014:    Reworded file description
 		- August 15th, 2014:    Added Net Requests
+		- April  25th, 2019:	Added Net Hooks, Global Vars, Client Vars, Persistence
 --------------------------------------------------------------------------------]]
 
 print( "[NetWrapper] Initializing netwrapper library" )

--- a/lua/netwrapper/cl_netwrapper.lua
+++ b/lua/netwrapper/cl_netwrapper.lua
@@ -86,6 +86,9 @@ hook.Add( "OnEntityCreated", "NetWrapperSync", function( ent )
 	
 	for key, value in pairs( values ) do
 		ent:SetNetVar( key, value )
+
+		netwrapper.NetVarChanged( id, key, value )
+		netwrapper.NetVarChanged( -1, key, value, id )  -- Hack: use entity ID -1 as an all-inclusive hook
 	end
 end )
 

--- a/lua/netwrapper/cl_netwrapper.lua
+++ b/lua/netwrapper/cl_netwrapper.lua
@@ -2,8 +2,9 @@
 	File name:
 		cl_netwrapper.lua
 	
-	Author:
+	Authors:
 		Mista-Tea ([IJWTB] Thomas)
+		xaviergmail (Xavier Bergeron)
 	
 	License:
 		The MIT License (copy/modify/distribute freely!)
@@ -12,6 +13,7 @@
 		- March 9th,   2014:    Created
 		- April 5th,   2014:    Added to GitHub
 		- August 15th, 2014:    Added Net Requests
+		- April  25th, 2019:	Added Net Hooks, Global Vars, Client Vars, Persistence
 ----------------------------------------------------------------------------]]
 
 --[[--------------------------------------------------------------------------

--- a/lua/netwrapper/example.lua
+++ b/lua/netwrapper/example.lua
@@ -2,8 +2,9 @@
 	File name:
 		example.lua
 	
-	Author:
+	Authors:
 		Mista-Tea ([IJWTB] Thomas)
+		xaviergmail (Xavier Bergeron)
 	
 	License:
 		The MIT License (copy/modify/distribute freely!)
@@ -12,11 +13,18 @@
 		- March   9th, 2014:    Created
 		- April   5th, 2014:    Added to GitHub
 		- August 16th, 2014:    Rewrote example for Net Vars / Net Requests
+		- April  25th, 2019:	Added examples for Client Vars / Global Vars / Hooks
+
+
 ----------------------------------------------------------------------------]]
 
 -- In this example, we will assign a player's name to the prop they spawn in PlayerSpawnedProp.
 -- We'll use Net Vars in the first example to show how they automatically network themselves,
 -- and then show how Net Requests can be used to ask for the value to be networked manually.
+-- We will also cover global variables as well as client variables which are only sent to 
+-- the specific client which is useful to reduce network impact.
+
+-- Example usage of hooks has been scattered throughout these examples
 
 
 

--- a/lua/netwrapper/example.lua
+++ b/lua/netwrapper/example.lua
@@ -27,11 +27,23 @@
 --                    Net Vars
 --[[-------------------------------------------]]--
 
+-- Helper function for demo
+local function fmtHook( ent, key, value )
+	local prefix = SERVER and "SERVER: " or "CLIENT: "
+	return prefix .. "Entity " .. tostring( ent ) .. " has just had their " ..
+	       key .. " NetVar changed to " .. value
+end
+
 if ( SERVER ) then
-	
+
 	-- when a player spawns a prop, assign the owner's name to it with ent:SetNetVar()
 	hook.Add( "PlayerSpawnedProp", "AssignOwner", function( ply, mdl, ent )
-	
+
+		-- Adds a net hook specific to this entity only. The same can be done clientside.
+		ent:AddNetHook( "Owner", "MyHookName", function( ent, key, value )
+			PrintMessage( HUD_PRINTTALK, fmtHook( ent, key, value ) )
+		end)
+
 		ent:SetNetVar( "Owner", ply:Nick() ) -- stores and networks the value to clients
 
 	end )
@@ -51,13 +63,19 @@ elseif ( CLIENT ) then
 		surface.SetFont( "default" )
 		local w, h = surface.GetTextSize( owner )
 		local x = ScrW() - w - 15
-		local y = ScrH() / 2.3
+		local y = ScrH() / 2.4
 		
 		draw.SimpleText( owner, "default", x, y, color_white, 0, 0 )
 	
 	end )
 	-- As soon as the server called ent:SetNetVar( "Owner", ply:Nick() ), the owner's name would be broadcasted to all clients.
 	-- The moment we look at the prop after it has been spawned, we'll be able to get the networked name with ent:GetNetVar( "Owner" ).
+
+	-- Example catch-all NetHook. This will get called any time an entity's Owner NetVar changes
+	-- The same can be done serverside.
+	netwrapper.AddNetHook("Owner", "MyHookName_cl", function( ent, key, value )
+		chat.AddText( fmtHook( ent, key, value ) )
+	end)
 	
 end
 
@@ -73,7 +91,7 @@ end
 if ( SERVER ) then
 	
 	-- when a player spawns a prop, assign the owner's name to it with ent:SetNetRequest()
-	hook.Add( "PlayerSpawnedProp", "AssignOwner", function( ply, mdl, ent )
+	hook.Add( "PlayerSpawnedProp", "AssignOwner_req", function( ply, mdl, ent )
 	
 		ent:SetNetRequest( "Owner", ply:Nick() ) -- stores the value but does not network it
 
@@ -82,7 +100,7 @@ if ( SERVER ) then
 elseif ( CLIENT ) then
 	
 	-- draw the owner's name of any entity we look at during HUDPaint
-	hook.Add( "HUDPaint", "DrawOwner", function()
+	hook.Add( "HUDPaint", "DrawOwner_req", function()
 	
 		if ( !IsValid( LocalPlayer() ) ) then return end
 		
@@ -106,4 +124,90 @@ elseif ( CLIENT ) then
 	-- if it does, it will reply with the value and the client will automatically use ent:SetNetRequest( "Owner", value ) so that any
 	-- subsequent calls to ent:GetNetRequest( "Owner" ) returns the value
 	
+end
+
+
+
+
+--[[-------------------------------------------]]--
+--                 Global Variables
+--[[-------------------------------------------]]--
+
+
+if ( SERVER ) then
+	
+	local colors = {
+		"Blue", "Red", "Green", "Yellow", "Magenta",
+		"Cyan", "Burgundy", "Beige", "Orange", "Pink"
+	}
+
+	timer.Create(" CycleColors", 3, 0, function()
+		netwrapper.SetGlobalVar ("Color", table.Random( colors ) )
+	end )
+	
+elseif ( CLIENT ) then
+	
+	hook.Add( "HUDPaint", "DrawColor", function()
+		
+		local color = netwrapper.GetGlobalVar( "Color" )
+		color = "Current Color: " .. color
+		
+		surface.SetFont( "default" )
+		local w, h = surface.GetTextSize( color )
+		local x = ScrW() - w - 15
+		local y = ScrH() / 2.5
+		
+		draw.SimpleText( color, "default", x, y, color_white, 0, 0 )
+	
+	end )
+	
+	netwrapper.AddGlobalHook( "Color", "MyHookName", function( key, value )
+		chat.AddText( "Color was changed to " .. value )
+	end )
+
+	-- If you wanted to remove the hook, you could do this:
+	-- netwrapper.RemoveGlobalHook( "Color", "MyHookName" )
+
+	-- Alternatively, you can pass any object with an IsValid method (panel, entity, etc)
+	-- as the hook name, and it will automatically get removed if IsValid() returns false.
+end
+
+
+--[[-------------------------------------------]]--
+--                 ClientVars
+--[[-------------------------------------------]]--
+
+
+if ( SERVER ) then
+	
+	local colors = {
+		"Blue", "Red", "Green", "Yellow", "Magenta",
+		"Cyan", "Burgundy", "Beige", "Orange", "Pink"
+	}
+
+	timer.Create( "CycleColors_Ply", 6, 0, function()
+		for k, v in pairs( player.GetAll() ) do
+			v:SetClientVar( "Color", table.Random( colors ) )
+		end
+	end )
+	
+elseif ( CLIENT ) then
+	
+	hook.Add( "HUDPaint", "DrawColor", function()
+		
+		local color = netwrapper.GetClientVar("Color")
+		color = "Current Client Color: " .. color
+		
+		surface.SetFont( "default" )
+		local w, h = surface.GetTextSize( color )
+		local x = ScrW() - w - 15
+		local y = ScrH() / 2.6
+		
+		draw.SimpleText( color, "default", x, y, color_white, 0, 0 )
+	
+	end )
+	
+	netwrapper.AddCLNetHook( "Color", "MyHookName", function( ent, key, value )
+		chat.AddText( "Client Color was changed to " .. value )
+	end)
 end

--- a/lua/netwrapper/sh_netwrapper.lua
+++ b/lua/netwrapper/sh_netwrapper.lua
@@ -120,7 +120,7 @@ end
 
 --[[--------------------------------------------------------------------------
 --
---	ENTITY:AddNetHook( string, string, function )
+--	ENTITY:AddNetHook( string, string, function( entity, key, value ) )
 --
 --	Adds a Net Hook that is to be called when the entity's NetVar[key] changes
 --  Uniquely identified by name to be later removed by ENTITY:RemoveNetHook
@@ -131,7 +131,7 @@ end
 
 --[[--------------------------------------------------------------------------
 --
---	ENTITY:AddNetHook( string, string, function )
+--	ENTITY:AddNetHook( string, string )
 --
 --	Removes the Net Hook on this entity referred to by NetVar key and hook Name
 --]]--
@@ -168,7 +168,7 @@ end
 
 --[[--------------------------------------------------------------------------
 --
---	netwrapper.StoreNetHook( int, string, string, function )
+--	netwrapper.StoreNetHook( int, string, string, function( entity, key, value ) )
 --
 --	Stores function fn tied to a NetVar key on the given entity index, identified by name
 --]]--
@@ -180,9 +180,11 @@ end
 
 --[[--------------------------------------------------------------------------
 --
---	netwrapper.AddNetHook( string, string, function )
+--	netwrapper.AddNetHook( string, string, function( entity, key, value ) )
 --
---	Stores function fn tied to a NetVar key on entity index -1, identified by name (used for catch-all hooks)
+--	Stores function fn tied to a NetVar key on entity index -1, identified by name
+--  This is a catch-all hook, meaning the hook is called whenever the NetVar of key
+--   changes on any entity.
 --]]--
 function netwrapper.AddNetHook( key, name, fn )
 	netwrapper.StoreNetHook( -1, key, name, fn )
@@ -265,7 +267,7 @@ netwrapper.CLNetHookPrefix = "ClientVar_"
 
 --[[--------------------------------------------------------------------------
 --
---	PLAYER:AddCLNetHook( string, string, function )
+--	PLAYER:AddCLNetHook( string, string, function( entity, key, value ) )
 --
 --	Adds a Net Hook that is to be called when the player's ClientVar[key] changes
 --  Uniquely identified by name to be later removed by ENTITY:RemoveCLNetHook
@@ -340,7 +342,7 @@ end
 
 --[[--------------------------------------------------------------------------
 --
---	netwrapper.AddGlobalHook( string, string, function )
+--	netwrapper.AddGlobalHook( string, string, function( key, value ) )
 --
 --	Equivalent to game.GetWorld():AddNetHook( ... )
 --]]--
@@ -350,7 +352,7 @@ end
 
 --[[--------------------------------------------------------------------------
 --
---	netwrapper:RemoveGlobalHook( string, string, function )
+--	netwrapper:RemoveGlobalHook( string, string, function( key, value ) )
 --
 --	Equivalent to game.GetWorld():RemoveNetHook( ... )
 --]]--

--- a/lua/netwrapper/sh_netwrapper.lua
+++ b/lua/netwrapper/sh_netwrapper.lua
@@ -2,8 +2,9 @@
 	File name:
 		sh_netwrapper.lua
 	
-	Author:
+	Authors:
 		Mista-Tea ([IJWTB] Thomas)
+		xaviergmail (Xavier Bergeron)
 	
 	License:
 		The MIT License (copy/modify/distribute freely!)
@@ -12,6 +13,7 @@
 		- March 9th,   2014:    Created
 		- April 5th,   2014:    Added to GitHub
 		- August 15th, 2014:    Added Net Requests
+		- April  25th, 2019:	Added Net Hooks, Global Vars, Client Vars, Persistence
 ----------------------------------------------------------------------------]]
 
 AddCSLuaFile()

--- a/lua/netwrapper/sh_netwrapper.lua
+++ b/lua/netwrapper/sh_netwrapper.lua
@@ -213,6 +213,51 @@ function netwrapper.NetVarChanged( id, key, value, realid )
 	end
 end
 
+--[[--------------------------------------------------------------------------
+--	GLOBAL NET VARS 
+--  Wrapper around netvar functions applied on the game.GetWorld() entity
+--------------------------------------------------------------------------]]--
+
+--[[--------------------------------------------------------------------------
+--
+--	netwrapper.SetGlobalVar( string, *, boolean [optional] )
+--
+--  Equivalent to game.GetWorld():SetNetVar( ... )
+--]]--
+
+function netwrapper.SetGlobalVar( key, value, force )
+	game.GetWorld():SetNetVar( key, value, force )
+end
+
+--[[--------------------------------------------------------------------------
+--
+--	netwrapper.GetGlobalVar( string, * )
+--
+--  Equivalent to game.GetWorld():GetNetVar( ... )
+--]]--
+function netwrapper.GetGlobalVar( key, default )
+	return game.GetWorld():GetNetVar( key, default )
+end
+
+--[[--------------------------------------------------------------------------
+--
+--	netwrapper.AddGlobalHook( string, string, function )
+--
+--	Equivalent to game.GetWorld():AddNetHook( ... )
+--]]--
+function netwrapper.AddGlobalHook( key, name, fn )
+	game.GetWorld():AddNetHook( key, name, fn )
+end
+
+--[[--------------------------------------------------------------------------
+--
+--	netwrapper:RemoveGlobalHook( string, string, function )
+--
+--	Equivalent to game.GetWorld():RemoveNetHook( ... )
+--]]--
+function netwrapper:RemoveGlobalHook( key, name )
+	game.GetWorld():RemoveNetHook( key, name )
+end
 
 --[[--------------------------------------------------------------------------
 --	NET REQUESTS

--- a/lua/netwrapper/sv_netwrapper.lua
+++ b/lua/netwrapper/sv_netwrapper.lua
@@ -2,8 +2,9 @@
 	File name:
 		sv_netwrapper.lua
 	
-	Author:
+	Authors:
 		Mista-Tea ([IJWTB] Thomas)
+		xaviergmail (Xavier Bergeron)
 	
 	License:
 		The MIT License (copy/modify/distribute freely!)
@@ -12,6 +13,7 @@
 		- March 9th,   2014:    Created
 		- April 5th,   2014:    Added to GitHub
 		- August 15th, 2014:    Added Net Requests
+		- April  25th, 2019:	Added Net Hooks, Global Vars, Client Vars, Persistence
 ----------------------------------------------------------------------------]]
 
 --[[--------------------------------------------------------------------------

--- a/lua/netwrapper/sv_netwrapper.lua
+++ b/lua/netwrapper/sv_netwrapper.lua
@@ -203,7 +203,8 @@ end
 --  Returns: The modified input table
 --]]--
 function netwrapper.FilterPersistentVars( tbl )
-	for k, v in pairs( tbl or {} ) do
+	tbl = tbl or {}
+	for k, v in pairs( tbl ) do
 		if not netwrapper.persistentvars[ k ] then
 			tbl[ k ] = nil
 		end


### PR DESCRIPTION
This is a fork I've been using personally for a while and I decided I might as well give back to the community so here it is. I'm making this PR to hopefully get it some extra publicity from the existing thread on the facepunch forum than trying to market my own fork.

These additions are what I feel make this library complete. I can't really think of anything else I'd like to add other than GM:NetRequest/Net/Client/GlobalVarChanged hook to capture every change regardless or entity or key but I can't think of a good use case for that, so I decided against it. I also think adding hooks to NetRequests should be relatively easy so that might be my next move.

This PR adds the following:
* NetVar Hooks ( Currently does not support net requests )
* ClientVars (NetVars that are only networked to a single client for say HUD elements and whatnot)
* GlobalVars (NetVars on game.GetWorld())
* Persistent Vars (Save and restore player volatile (current lua state only) variables (NetVar, NetRequest, ClientVar) on reconnect)

I suggest you view the [README](https://github.com/xaviergmail/netwrapper/blob/master/README.md) as well as the [examples](https://github.com/xaviergmail/netwrapper/blob/master/lua/netwrapper/example.lua)
